### PR TITLE
feat: lazily load offscreen images

### DIFF
--- a/index.html
+++ b/index.html
@@ -2341,7 +2341,7 @@ agar kamu mengingat (kebesaran Allah).“<br>
     
                             <!-- Kartu BCA -->
                             <div class="gift-card">
-                                <img src="img/BCA_logo_Bank_Central_Asia-1-3-2048x650-1-1.png" alt="Logo BCA" class="bank-logo">
+                                <img src="img/BCA_logo_Bank_Central_Asia-1-3-2048x650-1-1.png" alt="Logo BCA" class="bank-logo" loading="lazy">
                                 <p class="account-number" id="bca-number">147 058 9392</p>
                                 <p class="account-name">a.n. Sofyan Hadi</p>
                                 <button class="copy-button" onclick="copyToClipboard('bca-number', this)">
@@ -2351,7 +2351,7 @@ agar kamu mengingat (kebesaran Allah).“<br>
 
                             <!-- Kartu DANA -->
                             <div class="gift-card">
-                                <img src="https://upload.wikimedia.org/wikipedia/commons/2/2e/BRI_2020.svg" alt="Logo BRI" class="bank-logo">
+                                <img src="https://upload.wikimedia.org/wikipedia/commons/2/2e/BRI_2020.svg" alt="Logo BRI" class="bank-logo" loading="lazy">
                                 <p class="account-number" id="dana-number">6231 0104 9690 534</p>
                                 <p class="account-name">a.n. Sofyan Hadi</p>
                                 <button class="copy-button" onclick="copyToClipboard('dana-number', this)">
@@ -2447,27 +2447,27 @@ Kini kami menanti hari istimewa kami.								</div>
     
                                 <!-- Gambar 1 -->
                                 <a href="img/5.jpg" data-lightbox="wedding-gallery" data-title="Momen Bahagia 1" class="gallery-item">
-                                    <img src="img/5.jpg" alt="Foto Pernikahan 1" class="gallery-image">
+                                    <img src="img/5.jpg" alt="Foto Pernikahan 1" class="gallery-image" loading="lazy">
                                 </a>
                                 
                                 <!-- Gambar 2 -->
                                 <a href="img/6.jpg" data-lightbox="wedding-gallery" data-title="Momen Bahagia 2" class="gallery-item">
-                                    <img src="img/6.jpg" alt="Foto Pernikahan 2" class="gallery-image">
+                                    <img src="img/6.jpg" alt="Foto Pernikahan 2" class="gallery-image" loading="lazy">
                                 </a>
 
                                 <!-- Gambar 3 -->
                                 <a href="img/7.jpg" data-lightbox="wedding-gallery" data-title="Momen Bahagia 3" class="gallery-item">
-                                    <img src="img/7.jpg" alt="Foto Pernikahan 3" class="gallery-image">
+                                    <img src="img/7.jpg" alt="Foto Pernikahan 3" class="gallery-image" loading="lazy">
                                 </a>
 
                                 <!-- Gambar 4 -->
                                 <a href="img/8.jpg" data-lightbox="wedding-gallery" data-title="Calon Mempelai Pria" class="gallery-item">
-                                    <img src="img/8.jpg" alt="Foto Pria" class="gallery-image">
+                                    <img src="img/8.jpg" alt="Foto Pria" class="gallery-image" loading="lazy">
                                 </a>
 
                                 <!-- Gambar 5 -->
                                 <a href="img/10.jpg" data-lightbox="wedding-gallery" data-title="Calon Mempelai Wanita" class="gallery-item">
-                                    <img src="img/10.jpg" alt="Foto Wanita" class="gallery-image">
+                                    <img src="img/10.jpg" alt="Foto Wanita" class="gallery-image" loading="lazy">
                                 </a>
 
                                 <!-- Tambahkan gambar lain di sini jika perlu -->
@@ -2799,7 +2799,7 @@ Kini kami menanti hari istimewa kami.								</div>
                             <div class="elementor-element elementor-element-a267afc elementor-widget elementor-widget-text-editor" data-id="a267afc" data-element_type="widget" data-widget_type="text-editor.default">
                                 <div class="elementor-widget-container">
                                     <p>
-                                        <img decoding="async" class="emoji" role="img" draggable="false" src="https://s.w.org/images/core/emoji/13.0.1/svg/2764.svg" alt="❤"/>
+                                        <img decoding="async" class="emoji" role="img" draggable="false" src="https://s.w.org/images/core/emoji/13.0.1/svg/2764.svg" alt="❤" loading="lazy"/>
                                     </p>
                                 </div>
                             </div>


### PR DESCRIPTION
## Summary
- add lazy-loading to bank logos and gallery images to defer offscreen assets

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a1fd3724cc83208d48d75d17e0a3a2