### PR TITLE
Load wp i18n script before inline block

### DIFF
--- a/index.html
+++ b/index.html
@@ -2939,7 +2939,7 @@ Kini kami menanti hari istimewa kami.								</div>
     <script src="js/webpack.runtime.min.js?ver=3.28.4" id="elementor-webpack-runtime-js" defer></script>
     <!-- <script src="js/frontend-modules.min.js?ver=3.28.4" id="elementor-frontend-modules-js"></script> -->
     <script src="js/hooks.min.js?ver=4d63a3d491d11ffd8ac6" id="wp-hooks-js" defer></script>
-    <script src="js/i18n.min.js?ver=5e580eb46a90c2b997e6" id="wp-i18n-js" defer></script>
+    <script src="js/i18n.min.js?ver=5e580eb46a90c2b997e6" id="wp-i18n-js"></script>
     <script id="wp-i18n-js-after">
         wp.i18n.setLocaleData({
             'text direction\u0004ltr': ['ltr']


### PR DESCRIPTION
## Summary
- Ensure the wp i18n script runs before the inline block so `wp` is available

## Testing
- `node <<'NODE'
const fs = require('fs');
const vm = require('vm');
const context = { console };
context.window = context;
context.self = context;
context.global = context;
vm.createContext(context);
vm.runInContext(fs.readFileSync('./js/hooks.min.js','utf8'), context);
vm.runInContext(fs.readFileSync('./js/i18n.min.js','utf8'), context);
vm.runInContext("wp.i18n.setLocaleData({'text direction\\u0004ltr': ['ltr']});", context);
console.log('no wp errors');
NODE`


------
https://chatgpt.com/codex/tasks/task_e_68a29cb7899483208f8e35579acacf6a